### PR TITLE
message is part of the error tuple when failing to parse soap response message

### DIFF
--- a/src/yaws_soap_lib.erl
+++ b/src/yaws_soap_lib.erl
@@ -250,7 +250,7 @@ parseMessage(Message, Model) ->
                               'Header' = #'soap:Header'{choice = Header}}, _} ->
             {ok, Header, Body};
         {error, ErrorMessage} ->
-            {error, {decoding, ErrorMessage}}
+            {error, {decoding, Message, ErrorMessage}}
     end.
 
 


### PR DESCRIPTION
I was playing for the first time with Yaws and its soap library.  I tried different webservices for testing.  For most of them, I was getting the following error:

```erlang
Model = yaws_soap_lib:initModel("http://www.webservicex.net/CurrencyConvertor.asmx?WSDL").
yaws_soap_lib:call(Model1, "ConversionRate", ["USD", "CLP"]).
{error,{decoding,"Malformed: Illegal character in prolog"}}
```

I dug into the code a little bit and I realized that by default Yaws is passing `application/xml; charset=utf-8` as the `ContentType` in the request.  I changed that to be `text/xml; charset=utf-8` and I started getting good results.  I was fighting for so many hours the `{error,{decoding,"Malformed: Illegal character in prolog"}}` error that I think It would be useful, at least, to add the `Message` coming from the Request as part of the error tuple:

```erlang
Model = yaws_soap_lib:initModel("http://www.webservicex.net/CurrencyConvertor.asmx?WSDL").
yaws_soap_lib:call(Model1, "ConversionRate", ["USD", "CLP"]).
{error,{decoding,"The server cannot service the request because the media type is unsupported.",
                 "Malformed: Illegal character in prolog"}}
```