### PR TITLE
fix: external logger_mod module tried to init before ebin_dir is added to path

### DIFF
--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -167,10 +167,11 @@ init(Env) -> %% #env{Trace, TraceOut, Conf, RunMod, Embedded, Id}) ->
                                                [?format_record(_SC, sconf)])
                                 end, Group)
                       end, Sconfs),
-                    yaws_log:setup(Gconf, Sconfs),
                     yaws_trace:setup(Gconf),
-                    init2(Gconf, Sconfs, Env#env.runmod,
-                          Env#env.embedded, true);
+                    Res = init2(Gconf, Sconfs, Env#env.runmod,
+                          Env#env.embedded, true),
+                    yaws_log:setup(Gconf, Sconfs),
+                    Res;
                 {error, E} ->
                     case erase(logdir) of
                         undefined ->


### PR DESCRIPTION
I tried to use my custom logging module, which can be specified via logger_mod server variable in config file.
The problem is that when server tries to init this module it does that before ebin_dir from conf file is added to path and does that only once, thus this custom logging module does not get plugged in (if its beam file resides outside of yaws lib dir).