### PR TITLE
use read_link_info to handle symlinks

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -723,7 +723,7 @@ elog(F, As) ->
 
 
 filesize(Fname) ->
-    case file:read_file_info(Fname) of
+    case file:read_link_info(Fname) of
         {ok, FI} when FI#file_info.type == regular ->
             {ok, FI#file_info.size};
         {ok, FI} ->

--- a/src/yaws_config.erl
+++ b/src/yaws_config.erl
@@ -2340,7 +2340,7 @@ warn_dir(Type, Dir) ->
     end.
 
 is_dir(Val) ->
-    case file:read_file_info(Val) of
+    case file:read_link_info(Val) of
         {ok, FI} when FI#file_info.type == directory ->
             true;
         _ ->
@@ -2349,7 +2349,7 @@ is_dir(Val) ->
 
 
 is_file(Val) ->
-    case file:read_file_info(Val) of
+    case file:read_link_info(Val) of
         {ok, FI} when FI#file_info.type == regular ->
             true;
         _ ->

--- a/src/yaws_ctl.erl
+++ b/src/yaws_ctl.erl
@@ -124,7 +124,7 @@ w_ctl_file(Sid, Port, Key) ->
                  F = yaws:ctl_file(Sid),
                  error_logger:info_msg("Ctlfile : ~s~n", [F]),
                  file:write_file(F, io_lib:format("~w.", [{Port,Key}])),
-                 {ok, FI} = file:read_file_info(F),
+                 {ok, FI} = file:read_link_info(F),
                  ok = file:write_file_info(F, FI#file_info{mode = 8#00600})
              end of
              {'EXIT', _} ->
@@ -500,7 +500,7 @@ ls(_) ->
 
 lls(IdDir) ->
     CtlFile = yaws:ctl_file(IdDir),
-    case {file:read_file_info(CtlFile),
+    case {file:read_link_info(CtlFile),
           file:read_file(CtlFile)} of
         {{ok, FI}, {error, eacces}} ->
             User = yaws:uid_to_name(FI#file_info.uid),

--- a/src/yaws_dime.erl
+++ b/src/yaws_dime.erl
@@ -110,7 +110,7 @@ size_of(X) when is_list(X) ->
 size_of(X) when is_binary(X)->
     size(X);
 size_of({file, File}) ->
-    {ok,R} = file:read_file_info(File),
+    {ok,R} = file:read_link_info(File),
     R#file_info.size.
 
 get_data({file, File}) ->

--- a/src/yaws_log.erl
+++ b/src/yaws_log.erl
@@ -375,7 +375,7 @@ handle_info({'EXIT', _, _}, State) ->
 
 
 wrap_p(Filename, LogWrapSize) ->
-    case file:read_file_info(Filename) of
+    case file:read_link_info(Filename) of
         {ok, FI} when FI#file_info.size > LogWrapSize, LogWrapSize > 0 ->
             true;
         {ok, _FI} ->

--- a/src/yaws_log_file_h.erl
+++ b/src/yaws_log_file_h.erl
@@ -50,7 +50,7 @@ handle_call(wrap, {Fd, File, Prev}) ->
 
 handle_call(size, {Fd, File, Prev}) ->
     file:sync(Fd),
-    Return = case file:read_file_info(File) of
+    Return = case file:read_link_info(File) of
         {ok, FI} -> {ok, FI#file_info.size};
         Error -> Error
     end,

--- a/src/yaws_ls.erl
+++ b/src/yaws_ls.erl
@@ -30,7 +30,7 @@ list_directory(_Arg, CliSock, List, DirName, Req, DoAllZip) ->
     L0 = lists:zf(
            fun(F) ->
                    File = DirName ++ [$/|F],
-                   FI = file:read_file_info(File),
+                   FI = file:read_link_info(File),
                    file_entry(FI, DirName, F, Qry,Descriptions)
            end, List),
 
@@ -335,7 +335,7 @@ accumulate_forbidden_paths() ->
 dir_contains_indexfile(_Dir, []) ->
     false;
 dir_contains_indexfile(Dir, [File|R]) ->
-    case file:read_file_info(filename:join(Dir, File)) of
+    case file:read_link_info(filename:join(Dir, File)) of
         {ok, _} ->
             true;
         _Else ->
@@ -358,7 +358,7 @@ dig_through_dir(Basedirlen, Dir, ForbiddenPaths, RE_ForbiddenNames) ->
             {ok, Files} = file:list_dir(Dir),
             lists:foldl(fun(I, Acc) ->
                                 Filename = filename:join(Dir, I),
-                                case {file:read_file_info(Filename),
+                                case {file:read_link_info(Filename),
                                       re:run(Filename, RE_ForbiddenNames)} of
                                     {_, {match, _}} ->
                                         Acc;

--- a/src/yaws_sendfile.erl
+++ b/src/yaws_sendfile.erl
@@ -92,7 +92,7 @@ send(Out, Filename, Offset, Count) ->
 bytes_to_transfer(Filename, Offset, Count) ->
     case Count of
         all ->
-            case file:read_file_info(Filename) of
+            case file:read_link_info(Filename) of
                 {ok, #file_info{size = Size}} -> Size - Offset;
                 Error -> Error
             end;

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -461,7 +461,7 @@ do_listen(GC, SC) ->
 certinfo(SSL) ->
     #certinfo{
           keyfile = if SSL#ssl.keyfile /= undefined ->
-                            case file:read_file_info(SSL#ssl.keyfile) of
+                            case file:read_link_info(SSL#ssl.keyfile) of
                                 {ok, FI} ->
                                     FI#file_info.mtime;
                                 _ ->
@@ -471,7 +471,7 @@ certinfo(SSL) ->
                             undefined
                     end,
           certfile = if SSL#ssl.certfile /= undefined ->
-                             case file:read_file_info(SSL#ssl.certfile) of
+                             case file:read_link_info(SSL#ssl.certfile) of
                                  {ok, FI} ->
                                      FI#file_info.mtime;
                                  _ ->
@@ -481,7 +481,7 @@ certinfo(SSL) ->
                              undefined
                      end,
           cacertfile = if SSL#ssl.cacertfile /= undefined ->
-                               case file:read_file_info(SSL#ssl.cacertfile) of
+                               case file:read_link_info(SSL#ssl.cacertfile) of
                                    {ok, FI} ->
                                        FI#file_info.mtime;
                                    _ ->
@@ -2449,7 +2449,7 @@ handle_ut(CliSock, ARG, UT = #urltype{type = dav}, N) ->
                 options;
             _ when Req#http_request.method == 'GET';
                    Req#http_request.method == 'HEAD' ->
-                case prim_file:read_file_info(UT#urltype.fullpath) of
+                case prim_file:read_link_info(UT#urltype.fullpath) of
                     {ok, FI} when FI#file_info.type == regular ->
                         {regular, FI};
                     _ ->
@@ -3524,7 +3524,7 @@ ssi(File, Delimiter, Bindings, UT, ARG, SC) ->
 
 
 path_to_mtime(FullPath) ->
-    case prim_file:read_file_info(FullPath) of
+    case prim_file:read_link_info(FullPath) of
         {ok, FI} ->
             mtime(FI);
         Err ->
@@ -3760,7 +3760,7 @@ deflate_accumulated(Arg, Content, ContentLength, Mode) ->
                 %% implies Mode=={file,_,_} and use_gzip_static==true
                 {file, File, MTime} = Mode,
                 GzFile = File++".gz",
-                case prim_file:read_file_info(GzFile) of
+                case prim_file:read_link_info(GzFile) of
                     {ok, FI} when FI#file_info.type == regular,
                                   FI#file_info.mtime >= MTime ->
                         {{gzfile, GzFile}, <<>>, FI#file_info.size};
@@ -4252,7 +4252,7 @@ do_url_type(SC, GetPath, ArgDocroot, VirtualDir) ->
                 false ->
                     ?Debug("FullPath = ~p~n", [FullPath]),
 
-                    case prim_file:read_file_info(FullPath) of
+                    case prim_file:read_link_info(FullPath) of
                         {ok, FI} when FI#file_info.type == regular ->
                             {Type, Mime} = suffix_type(SC, RevFile),
                             #urltype{type=Type,
@@ -4544,7 +4544,7 @@ try_index_file(FullPath, GetPath, [[$/|_]=Idx|Rest]) ->
         false -> {redir, Idx}
     end;
 try_index_file(FullPath, GetPath, [Idx|Rest]) ->
-    case prim_file:read_file_info([FullPath, Idx]) of
+    case prim_file:read_link_info([FullPath, Idx]) of
         {ok, FI} when FI#file_info.type == regular ->
             {index, Idx};
         _ ->
@@ -4664,7 +4664,7 @@ path_info_split(SC, [H|T], {DR, VirtualDir}, AccPathInfo) ->
 
                     ?Debug("Testing for script at: ~p~n", [FullPath]),
 
-                    case prim_file:read_file_info(FullPath) of
+                    case prim_file:read_link_info(FullPath) of
                         {ok, FI} when FI#file_info.type == regular ->
                             {ok, FI, FullPath, lists:reverse(T),
                              string:strip(H,right,$/), AccPathInfo, X, Mime};


### PR DESCRIPTION
please double-check this PR carefully.

the trigger to this PR was #205 where my thoughts were that the etags should not be related to the symlink itself, but to the resolved target (client knows nothing and should not know how the static resources are stored on the server)