### PR TITLE
Fix possible XSS in yaws_outmod:crashmsg/3

### DIFF
--- a/src/yaws_outmod.erl
+++ b/src/yaws_outmod.erl
@@ -99,5 +99,5 @@ crashmsg(_Arg, _SC, L) ->
      [{h2, [], "Internal error, yaws code crashed"},
       {br},
       {hr},
-      {pre, [], L},
+      {pre, [], yaws_api:htmlize(L)},
       {hr}]}.


### PR DESCRIPTION
Stacktraces have a dump of arguments for function calls
nowadays. Without escaping HTML special characters, it is possible to
make `yaws_outmod:crashmsg/3` dump strings containing something like
`"</pre><script>alert('Hello, XSS!')</script>"` and thus results in a
XSS vulnerability.