### PR TITLE
Fix max connections

### DIFF
--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1107,6 +1107,7 @@ acceptor0(GS, Top) ->
                 {'EXIT', Reason2} ->
                     error_logger:error_msg("Yaws process died: ~p~n",
                                            [Reason2]),
+                    Top ! {self(), decrement},
                     exit(shutdown)
             end,
 

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1095,6 +1095,9 @@ acceptor0(GS, Top) ->
                 {'EXIT', {{error, einval}, _}} ->
                     Top ! {self(), decrement},
                     exit(normal);
+                {'EXIT', {{badmatch, {error, einval}}, _}} ->
+                    Top ! {self(), decrement},
+                    exit(normal);
                 {'EXIT', {error, closed}} ->
                     Top ! {self(), decrement},
                     exit(normal);


### PR DESCRIPTION
When the server dies, the number of connections wasn't getting decremented.
When having `max_connections` set to anything but `nolimit`, once the maximum number of connections is reached, the server dies, but doesn't decrement, meaning that the only `max_connections -1` connections are available from there on. Next time there is a connection above that, only `max_connections -1 -1` connections are available from there on, etc.

The 2nd commit handles the badmatch that surfaces in `yaws:set_opts/3` - when the socket is closed, `inet:setopts` returns `{error, einval}`, which doesn't match `ok` -  as a "normal"=expected exit error reason.

PS: in #218 I mentioned that at times I could notice my appmod's `out` function was still called (my function was later failing because of another badmatch on {error, einval}). I cannot reproduce that now, with this fix, but it seems like a race-condition issue, which means it might surface in other contexts.