### PR TITLE
UTF-8 fix for www/yman.yaws and served man pages

### DIFF
--- a/www/TAB.inc
+++ b/www/TAB.inc
@@ -8,7 +8,7 @@ PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
 <head>
  <meta name="keywords" content="Yaws"/>
  <title>Yaws</title>
- <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"/>
+ <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
  <link rel="stylesheet" type="text/css" href="stil.css"/>
  <link rel="shortcut icon" href="/icons/yaws_y.gif" type="image/x-icon"/>
 </head>

--- a/www/yman.yaws
+++ b/www/yman.yaws
@@ -35,7 +35,7 @@ out(A) ->
                 "no man page found in query arg "
         end,
 
-    Man = {ehtml, {'div', [{id, "entry"}], prebox(L)}},
+    Man = {ehtml, {'div', [{id, "entry"}], prebox(unicode:characters_to_binary(L))}},
     Trail = {ssi, "END2",[],[]},
     [H, Man, Trail].
 


### PR DESCRIPTION
Yaws built with autotools or rebar would crash while trying to
serve man pages if os:cmd/1 returned utf-8 encoded strings.

- www/yman.yaws
Using unicode:characters_to_binary/1 for correct encoding
Issue https://github.com/klacke/yaws/issues/212 solves this in a similar way.

- www/TAB.inc
Changed charset to utf-8 in <head> to handle splitting
long words in line boundary ("â€" => "-").

As far as I know unicode:characters_to_binary(Data) wouldn't
be a problem even if the input is in latin1 because according
to the doc:
Data = latin1_chardata() | chardata() | external_chardata()

ISO-8859-1 is also compatible with UTF-8 therefore changing
the charset shouldn't be the problem either.