### PR TITLE
Revert "Fix HTTP authentication when user-defined module is used"

### DIFF
--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -2075,7 +2075,7 @@ handle_auth(ARG, _Auth_H, Auth_methods=#auth{users=[],pam=false,mod=[]}, Ret) ->
     {Ret, Auth_methods};
 
 handle_auth(ARG, Auth_H, Auth_methods = #auth{mod = Mod}, Ret) when Mod /= [] ->
-    case catch Mod:auth(ARG, Auth_H) of
+    case catch Mod:auth(ARG, Auth_methods) of
         {'EXIT', Reason} ->
             L = ?F("authmod crashed ~n~p:auth(~p, ~n ~p) \n"
                    "Reason: ~p~n"

--- a/test/t3/authmodtest.erl
+++ b/test/t3/authmodtest.erl
@@ -5,7 +5,7 @@
 -include("../../include/yaws_api.hrl").
 
 
-auth(Arg, _Auth) ->
+auth(#arg{}=Arg, #auth{}) ->
     H = Arg#arg.headers,
     case H#headers.authorization of
         {"foo", "bar", _} ->

--- a/test/t3/outmodtest.erl
+++ b/test/t3/outmodtest.erl
@@ -5,9 +5,9 @@
 -include("../../include/yaws_api.hrl").
 
 
-auth(_Arg, _Auth) ->
+auth(#arg{}, #auth{}) ->
     {appmod, ?MODULE}.
 
-out401(_Arg, _Auth, Realm) ->
+out401(#arg{}, #auth{}, Realm) ->
     [{status, 200}, {header, "X-Outmod-Test: true"},
      {content, "text/plain", Realm}].


### PR DESCRIPTION
This reverts commit 6cfcabd46a1db887e442130ba271d9831e4a5cd2.

After the said commit being introduced, user-defined authmod modules stopped working due to record type mismatch `{badrecord,auth}`. I edited the test `t3` so that we can prevent this sort of error. This fixes #232.