### PR TITLE
Adjustments for Gentoo Linux

### DIFF
--- a/scripts/gentoo/yaws-2.0.2.ebuild
+++ b/scripts/gentoo/yaws-2.0.2.ebuild
@@ -1,0 +1,32 @@
+# $Header: $
+
+EAPI="2"
+
+inherit eutils
+
+DESCRIPTION="Yaws is a high performance HTTP 1.1 web server."
+HOMEPAGE="http://yaws.hyber.org/"
+SRC_URI="http://yaws.hyber.org/download/${P}.tar.gz"
+LICENSE="BSD"
+SLOT="0"
+KEYWORDS="x86 amd64"
+IUSE=""
+
+DEPEND="dev-lang/erlang"
+
+src_install() {
+        make DESTDIR=${D} install || edie
+        keepdir /var/log/yaws
+        rmdir ${D}var/lib/log/yaws
+        rmdir ${D}var/lib/log
+        # We need to keep these directories so that the example yaws.conf works
+        # properly
+        keepdir /usr/lib/yaws/examples/ebin
+        keepdir /usr/lib/yaws/examples/include
+        dodoc ChangeLog LICENSE README
+}
+
+pkg_postinst() {
+        einfo "An example YAWS configuration has been setup to run on"
+        einfo "Please edit /etc/yaws/yaws.conf to suit your needs."
+}

--- a/scripts/gentoo/yaws.init
+++ b/scripts/gentoo/yaws.init
@@ -16,12 +16,11 @@ yaws=%bindir%/yaws
 
 conf="--conf %etcdir%/yaws/yaws.conf"
 
-opts="start stop reload restart query"
+extra_commands="reload query"
 
 depend() {
        need net
 }
-
 
 start() {
        ebegin "Starting yaws "
@@ -30,14 +29,12 @@ start() {
        eend $?
 }
 
-
 stop() {
        ebegin "Stopping yaws "
        ${yaws} ${idopts} --stop
        ${yaws} ${idopts} --wait-stopped=10
        eend $?
 }
-
 
 reload() {
        ebegin "Reloading yaws "
@@ -50,4 +47,3 @@ query() {
        ${yaws} ${idopts} --status
        eend $?
 }
-


### PR DESCRIPTION
The init script for Gentoo Linux needed adjustment after Gentoo made
some developments.  Additionally, the ebuild script for Gentoo Linux was
removed at some point, but it is rather helpful for anyone running
Gentoo Linux.