### PR TITLE
Set up log event handler earlier at startup

### DIFF
--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -167,11 +167,9 @@ init(Env) -> %% #env{Trace, TraceOut, Conf, RunMod, Embedded, Id}) ->
                                                [?format_record(_SC, sconf)])
                                 end, Group)
                       end, Sconfs),
-                    yaws_trace:setup(Gconf),
-                    Res = init2(Gconf, Sconfs, Env#env.runmod,
-                          Env#env.embedded, true),
                     yaws_log:setup(Gconf, Sconfs),
-                    Res;
+                    yaws_trace:setup(Gconf),
+                    init2(Gconf, Sconfs, Env#env.runmod, Env#env.embedded, true);
                 {error, E} ->
                     case erase(logdir) of
                         undefined ->


### PR DESCRIPTION
In http://sourceforge.net/p/erlyaws/mailman/message/34701725/ a user
reported that with Yaws 2.x, info reports that occur at startup
providing details about config file, control file, and the endpoints
upon which Yaws is listening were not being emitted into report.log,
which is different behavior than that of Yaws 1.x. This commit
reorders the yaws_log setup in yaws_server:init so all but the initial
"Yaws: Using config file..." message makes it into report.log.