### PR TITLE
remove error_logger call on websockets when sending the keep alive

### DIFF
--- a/src/yaws_websockets.erl
+++ b/src/yaws_websockets.erl
@@ -301,7 +301,6 @@ handle_info(timeout, #state{close_timer=TRef}=State) when TRef /= undefined ->
 
 %% Keepalive timeout: send a ping frame and wait for any reply
 handle_info(timeout, #state{wait_pong_frame=false}=State) ->
-    error_logger:info_msg("Send ping frame", []),
     GracePeriod = get_opts(keepalive_grace_period, State#state.opts),
     do_send(State#state.wsstate, {ping, <<>>}),
     {noreply, State#state{wait_pong_frame=true}, GracePeriod};


### PR DESCRIPTION
Hi,

The keep alive for websockets has a timeout that prints out the below; this logs very often depending on the number of connections.

Please could we remove it as per the PR; as it is not an error/needed as not an error; and if the request times out you would still get end point has gone away message.


=INFO REPORT==== 12-Jan-2016::13:34:12 ===
Send ping frame
=INFO REPORT==== 12-Jan-2016::13:34:22 ===
Send ping frame
