### PR TITLE
Fix trace log not catching the first request (refactoring)

### DIFF
--- a/src/yaws_config.erl
+++ b/src/yaws_config.erl
@@ -3055,14 +3055,7 @@ soft_setconf(GC, Groups, OLDGC, OldGroups) ->
 
 
 hard_setconf(GC, Groups) ->
-    yaws_trace:setup(GC),
-    case gen_server:call(yaws_server,{setconf, GC, Groups},infinity) of
-        ok ->
-            yaws_log:setup(GC, Groups);
-        E ->
-            erlang:error(E)
-    end.
-
+    gen_server:call(yaws_server,{setconf, GC, Groups}, infinity).
 
 
 remove_old_scs([Sc|Scs], NewGroups) ->

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -167,8 +167,6 @@ init(Env) -> %% #env{Trace, TraceOut, Conf, RunMod, Embedded, Id}) ->
                                                [?format_record(_SC, sconf)])
                                 end, Group)
                       end, Sconfs),
-                    yaws_log:setup(Gconf, Sconfs),
-                    yaws_trace:setup(Gconf),
                     init2(Gconf, Sconfs, Env#env.runmod, Env#env.embedded, true);
                 {error, E} ->
                     case erase(logdir) of
@@ -243,6 +241,8 @@ init2(GC, Sconfs, RunMod, Embedded, FirstTime) ->
 
     runmod(RunMod, GC),
     yaws_config:compile_and_load_src_dir(GC),
+    yaws_log:setup(GC, Sconfs),
+    yaws_trace:setup(GC),
     L2 = lists:zf(fun(Group) -> start_group(GC, Group) end,
                   yaws_config:load_mime_types_module(GC, Sconfs)),
     {ok, #state{gc       = GC,


### PR DESCRIPTION
I see klacke already committed a fix for the issue in https://github.com/klacke/yaws/commit/ebfb12c8f395b0c9b3ad01fb3a3866ac735f7c0c

Without knowing his commit, I ended up with a little cleaning/deduplication instead.
Have a look, but maybe it's not worth it.