### PR TITLE
Fix yaws_api:url_encode/1 to handle unicode chars

### DIFF
--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -792,7 +792,7 @@ url_decode_with_encoding(Path, Encoding) ->
                    latin1 ->
                        DecPath;
                    utf8 ->
-                       case unicode:characters_to_list(list_to_binary(DecPath)) of
+                       case unicode:characters_to_binary(DecPath) of
                            UTF8DecPath when is_list(UTF8DecPath) -> UTF8DecPath;
                            _ -> DecPath
                        end
@@ -878,30 +878,25 @@ url_decode_q_split([], Ack) ->
     {path_norm_reverse(Ack), []}.
 
 
+url_encode(URL) when is_list(URL) ->
+    Bin = unicode:characters_to_binary(URL),
+    %% ReservedChars = "!*'();:@&=+$,/?%#[]",
+    UnreservedChars = sets:from_list("ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                     "abcdefghijklmnopqrstuvwxyz"
+                                     "0123456789-_.~"),
+    flatten([url_encode_byte(Byte, UnreservedChars) || <<Byte>> <= Bin]).
 
-url_encode([H|T]) when is_list(H) ->
-    [url_encode(H) | url_encode(T)];
-url_encode([H|T]) ->
-    if
-        H >= $a, $z >= H ->
-            [H|url_encode(T)];
-        H >= $A, $Z >= H ->
-            [H|url_encode(T)];
-        H >= $0, $9 >= H ->
-            [H|url_encode(T)];
-        H == $_; H == $.; H == $-; H == $/; H == $: -> % FIXME: more..
-            [H|url_encode(T)];
-        true ->
-            case yaws:integer_to_hex(H) of
-                [X, Y] ->
-                    [$%, X, Y | url_encode(T)];
-                [X] ->
-                    [$%, $0, X | url_encode(T)]
+url_encode_byte($:, _) -> $:;
+url_encode_byte($/, _) -> $/;
+url_encode_byte(Byte, UnreservedChars) ->
+    case sets:is_element(Byte, UnreservedChars) of
+        true -> Byte;
+        false ->
+            case yaws:integer_to_hex(Byte) of
+                [X, Y] -> [$%, X, Y];
+                [X]    -> [$%, $0, X]
             end
-     end;
-
-url_encode([]) ->
-    [].
+    end.
 
 
 

--- a/src/yaws_ls.erl
+++ b/src/yaws_ls.erl
@@ -427,7 +427,7 @@ file_entry({ok, FI}, _DirName, Name, Qry, Descriptions) ->
            "  </tr>\n",
            ["/icons/" ++ Gif,
             Alt,
-            yaws_api:url_encode(EncName) ++ QryStr,
+            yaws_api:url_encode(Name) ++ QryStr,
             EncName,
             trim(EncName,?FILE_LEN_SZ),
             datestr(FI),


### PR DESCRIPTION
This PR makes it possible for Yaws to serve a directory tree that may contain non-latin1 chars in dir/file names. Please review. Thanks.