### PR TITLE
Improve yaws_ls:trim/3 to trim at UTF8 char boundary

### DIFF
--- a/test/eunit/Makefile.am
+++ b/test/eunit/Makefile.am
@@ -12,7 +12,8 @@ MODULES = multipart_post_parsing.erl	\
 	  proc_cleanup.erl		\
 	  subconfig.erl			\
 	  copy_error_log.erl		\
-	  dynopts.erl
+	  dynopts.erl			\
+	  yaws_ls_tests.erl
 
 EXTRA_DIST = $(MODULES) cookies.dump setcookies.dump subconfig_DATA
 

--- a/test/eunit/yaws_ls_tests.erl
+++ b/test/eunit/yaws_ls_tests.erl
@@ -1,0 +1,17 @@
+%% -*- coding: utf-8; -*-
+-module(yaws_ls_tests).
+-include_lib("eunit/include/eunit.hrl").
+
+trim_helper(Expected, Input, Len) ->
+    Enc = binary_to_list(unicode:characters_to_binary(Input)),
+    ExpectedEnc = binary_to_list(unicode:characters_to_binary(Expected)),
+    ExpectedEnc =:= yaws_ls:trim(Enc, Len).
+
+trim_test_() ->
+    %% [19990,30028,26479] =:= "世界杯"
+    %% [19990,30028,26479,36275,29699,36187] =:= "世界杯足球赛"
+    %% Written in this way to support OTP < R16B.
+    [?_assert(trim_helper([19990,30028,26479|"..&gt;"],
+                          [19990,30028,26479,36275,29699,36187],
+                          11)),
+     ?_assert(trim_helper("xxxxxxxx..&gt;", "xxxxxxxxxxxx", 11))].


### PR DESCRIPTION
Before this commit:

```
世界足球d运动会开始了全世界��..>
```

After this commit:

```
世界足球d运动会开始了全世界都..>
```