### PR TITLE
Don't crash on unknown query string in yaws_ls:parse_query/1

### DIFF
--- a/src/yaws_ls.erl
+++ b/src/yaws_ls.erl
@@ -19,7 +19,7 @@
 -export([list_directory/6, out/1]).
 
 %% Exports for EUNIT.
--export([trim/2]).
+-export([parse_query/1, trim/2]).
 
 -define(FILE_LEN_SZ, 45).
 
@@ -91,10 +91,13 @@ parse_query(Path) ->
     case string:tokens(Path, [$?]) of
         [DirStr, [PosC, $=, DirC] = Q] ->
             Pos = case PosC of
-                      $N -> 1; % name
+                      $m -> 2;
                       $M -> 2; % last modified
+                      $s -> 3;
                       $S -> 3; % size
-                      $D -> 4  % Description
+                      $d -> 4;
+                      $D -> 4; % description
+                      _  -> 1  % name (default)
                   end,
             Dir = case DirC of
                       $r -> reverse;

--- a/test/eunit/yaws_ls_tests.erl
+++ b/test/eunit/yaws_ls_tests.erl
@@ -15,3 +15,14 @@ trim_test_() ->
                           [19990,30028,26479,36275,29699,36187],
                           11)),
      ?_assert(trim_helper("xxxxxxxx..&gt;", "xxxxxxxxxxxx", 11))].
+
+parse_query_test_() ->
+    [
+        ?_assertEqual({"/", 1, normal,  "/?z=x"}, yaws_ls:parse_query("/?z=x")),
+        ?_assertEqual({"/", 2, reverse, "/?m=r"}, yaws_ls:parse_query("/?m=r")),
+        ?_assertEqual({"/", 2, reverse, "/?M=r"}, yaws_ls:parse_query("/?M=r")),
+        ?_assertEqual({"/", 3, normal,  "/?s=n"}, yaws_ls:parse_query("/?s=n")),
+        ?_assertEqual({"/", 3, normal,  "/?S=n"}, yaws_ls:parse_query("/?S=n")),
+        ?_assertEqual({"/", 4, reverse, "/?d=r"}, yaws_ls:parse_query("/?d=r")),
+        ?_assertEqual({"/", 4, reverse, "/?D=r"}, yaws_ls:parse_query("/?D=r"))
+    ].


### PR DESCRIPTION
and also make it case-insensitive.