### PR TITLE
Prevent report.log to be overwrittern upon Yaws restart

### DIFF
--- a/src/yaws_log_file_h.erl
+++ b/src/yaws_log_file_h.erl
@@ -25,11 +25,11 @@
 %% This one is used when we are started directly.
 init(File) ->
     process_flag(trap_exit, true),
-    Version = erlang:system_info(version),
+    {ok, [Version], _} = io_lib:fread("~d", erlang:system_info(version)),
     case file:open(File, [append]) of
-        {ok, Fd} when Version < "7" ->  %% Pre 18.1
+        {ok, Fd} when Version < 7 ->  %% Pre 18.1
             {ok, {Fd, File, []}};
-        {ok, Fd} ->                     %% Post 18.1
+        {ok, Fd} ->                   %% Post 18.1
             {ok, {st, Fd, File, [], unlimited}};
         Error ->
             error_logger:error_msg(

--- a/src/yaws_log_file_h.erl
+++ b/src/yaws_log_file_h.erl
@@ -24,13 +24,13 @@
 
 %% This one is used when we are started directly.
 init(File) ->
-    case error_logger_file_h:init(File) of
-        {ok, {Fd, File, PrevHandler}} -> %% Pre 18.1
-            file:position(Fd, eof),
-            {ok, {Fd, File, PrevHandler}};
-        {ok,  {st, Fd, File, PrevHandler, Depth}} -> %% Post 18.1
-            file:position(Fd, eof),
-            {ok,  {st, Fd, File, PrevHandler, Depth}};
+    process_flag(trap_exit, true),
+    Version = erlang:system_info(version),
+    case file:open(File, [append]) of
+        {ok, Fd} when Version < "7" ->  %% Pre 18.1
+            {ok, {Fd, File, []}};
+        {ok, Fd} ->                     %% Post 18.1
+            {ok, {st, Fd, File, [], unlimited}};
         Error ->
             error_logger:error_msg(
               "Failed to set Yaws error report handler: ~p~n", [Error]


### PR DESCRIPTION
We got the case in production where a node restarted again and again.
When we wanted to have a look to report.log, it was not possible as it was overwritten at each restart.

Basically, it's  a problem of file:open with [write] or [append]. This patch reverts to previous behaviour (append) while trying to preserve possible returns from error_logger_file_h:init(File) depending on OTP version.

The real patch would probably be to handle an internal format for the gen_event state rather than reusing the unofficial one from error_logger_file_h, but it would more lines of code ;)