### PR TITLE
Purge old code of yaws_dynopts after loading

### DIFF
--- a/src/yaws_dynopts.erl
+++ b/src/yaws_dynopts.erl
@@ -20,6 +20,7 @@
          connection_information/2,
 
          generate/1,
+         purge_old_code/0,
          is_generated/0
         ]).
 
@@ -152,6 +153,8 @@ compare_digit(X1, X2) ->
 %% %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 is_generated() -> false.
 
+purge_old_code() -> not_necessary.
+
 generate(GC) ->
     code:ensure_loaded(crypto),
     code:ensure_loaded(inet),
@@ -248,11 +251,13 @@ source() ->
            "    connection_information/2,",
            "",
            "    generate/1,",
+           "    purge_old_code/0,",
            "    is_generated/0",
            "   ]).",
            "",
            "",
            "generate(_) -> ok.",
+           "purge_old_code() -> code:soft_purge(?MODULE).",
            "is_generated() -> true.",
            "",
            "have_ssl_honor_cipher_order()   -> ?HAVE_SSL_HONOR_CIPHER_ORDER.",

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -239,6 +239,7 @@ init2(GC, Sconfs, RunMod, Embedded, FirstTime) ->
     runmod(RunMod, GC),
     yaws_config:compile_and_load_src_dir(GC),
     yaws_dynopts:generate(GC),
+    yaws_dynopts:purge_old_code(),
     yaws_log:setup(GC, Sconfs),
     yaws_trace:setup(GC),
     L2 = lists:zf(fun(Group) -> start_group(GC, Group) end,


### PR DESCRIPTION
After starting Yaws the yaws_dynopts module has old code loaded:

    > erlang:check_old_code(yaws_dynopts).
    true

This causes Erlang/OTP monitoring systems like WombatOAM to raise an
alarm:

    New alarm raised.
    Alarm id: {old_code,yaws_dynopts}.
    Additional information: <<"yaws_dynopts has old code loaded">>

This patch purges the old code if the generated yaws_dynopts module is
loaded. It cannot be done in the yaws_dynopts itself.