### PR TITLE
Fix writing of yaws_dynopts.erl if path contains tilde

### DIFF
--- a/src/yaws_dynopts.erl
+++ b/src/yaws_dynopts.erl
@@ -198,14 +198,7 @@ generate1(ModFile) ->
     end.
 
 write_module(ModFile) ->
-    case file:open(ModFile, [write]) of
-        {ok, Fd} ->
-            io:format(Fd, source(), []),
-            file:close(Fd),
-            ok;
-        {error, Reason} ->
-            {error, Reason}
-    end.
+    file:write_file(ModFile, source()).
 
 compile_options() ->
     [binary, report,


### PR DESCRIPTION
Writing of yaws_dynopts.erl fails if the Yaws include path contains a tilde (`~`) character. This happens often on Windows for long paths (e.g. `c:/Users/ADMINI~1/repos/yaws`).

Reproduce:

    git clone https://github.com/klacke/yaws.git yaws~1
    autoreconf -fi && ./configure && make && make test
    [...]
    Kernel pid terminated (application_controller) ({application_start_failure,yaws,{{shutdown,{failed_to_start_child,yaws_server,{badarg,[{io,format,[<0.168.0>,"-module(yaws_dynopts).\n\n-include(\"/home ...