### PR TITLE
Replaced deprecated crypto:rand_uniform/2 with rand:uniform/1.

### DIFF
--- a/src/yaws_ctl.erl
+++ b/src/yaws_ctl.erl
@@ -61,8 +61,7 @@ rand() ->
             yaws_dynopts:random_uniform(1 bsl 64);
         _ ->
             try
-                crypto:start(),
-                crypto:rand_uniform(0, 1 bsl 64)
+                rand:uniform(1 bsl 64) - 1
             catch
                 _:_ ->
                     error_logger:warning_msg("Running without crypto app\n"),


### PR DESCRIPTION
When I tried to compile Yaws with the latest Erlang (built from source), I got this error:

`yaws_ctl.erl:65: crypto:rand_uniform/2 is deprecated and will be removed in a future release; use rand:uniform/1`

So, I replaced:

`crypto:rand_uniform(Lo, Hi) -> N
    , Lo =< N < Hi`

with

`rand:uniform(N) -> X
    , 1 <= X <= N`