### PR TITLE
Handle requests with multiple Accept headers

### DIFF
--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -2451,8 +2451,13 @@ http_collect_headers(CliSock, Req, H, SSL, Count) when Count < 1000 ->
             http_collect_headers(CliSock, Req,
                                  H#headers{connection = Conn},SSL, Count+1);
         {ok, {http_header, _Num, 'Accept', _, Accept}} ->
-            http_collect_headers(CliSock, Req, H#headers{accept = Accept},
-                                 SSL, Count+1);
+            %% Here we just collect all Accept headers, at http_eoh we verify
+            %% and build one Accept header.
+            NewAcceptH = case H#headers.accept of
+                             undefined -> H#headers{accept = [Accept]};
+                             AcceptL   -> H#headers{accept = [Accept|AcceptL]}
+                         end,
+            http_collect_headers(CliSock, Req, NewAcceptH, SSL, Count+1);
         {ok, {http_header, _Num, 'If-Modified-Since', _, X}} ->
             http_collect_headers(CliSock, Req,
                                  H#headers{if_modified_since = X},SSL, Count+1);
@@ -2519,7 +2524,13 @@ http_collect_headers(CliSock, Req, H, SSL, Count) when Count < 1000 ->
                                          SSL, Count+1)
             end;
         {ok, http_eoh} ->
-            H;
+            %% NOTE empty Accept headers will be stripped!
+            case build_accept_hdr(H#headers.accept) of
+                {error, empty_accept_header_list = Err} ->
+                    {error, {Err, Req#http_request{method = bad_request}}};
+                AcceptHdrs ->
+                    H#headers{accept = AcceptHdrs}
+            end;
 
         %% these are here to be a little forgiving to
         %% bad (typically test script) clients
@@ -2541,6 +2552,28 @@ http_collect_headers(CliSock, Req, H, SSL, Count) when Count < 1000 ->
 http_collect_headers(_CliSock, Req, _H, _SSL, _Count)  ->
     {error, {too_many_headers, Req}}.
 
+
+%% @doc Filter out empty accept headers from list.
+-spec split_accept_hdrs([string()]) -> [string()].
+split_accept_hdrs([]) ->
+    [];
+split_accept_hdrs([Hdr|AcceptHdrs]) ->
+    [H || H <- [string:strip(S) || S <- string:tokens(Hdr, ",")], H /= [] ]
+        ++ split_accept_hdrs(AcceptHdrs).
+
+
+%% @doc Build one Accept header from the collected Accept headers.
+-spec build_accept_hdr([string()] | undefined) ->
+    string() | undefined | {error, empty_accept_header_list}.
+build_accept_hdr(undefined) ->
+    undefined;
+build_accept_hdr(AcceptHdrs) ->
+    AcceptHdrsReqOrder = lists:reverse(AcceptHdrs),
+    case split_accept_hdrs(AcceptHdrsReqOrder) of
+        []  -> {error, empty_accept_header_list};
+        [Hdr] -> Hdr;
+        Hdrs  -> string:join(Hdrs, ", ")
+    end.
 
 
 parse_auth(Orig = "Basic " ++ Auth64) ->

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1190,6 +1190,17 @@ aloop(CliSock, {IP,Port}=IPPort, GS, Num) ->
     process_flag(trap_exit, true),
     ?Debug("Head = ~p~n", [Head]),
     case Head of
+        {error, {empty_accept_header_list, ReqEmptyAccept}} ->
+            ?Debug("Request's Accept headers all empty~n", []),
+            case pick_sconf(GS#gs.gconf, #headers{}, GS#gs.group) of
+                undefined ->
+                    deliver_400(CliSock, ReqEmptyAccept);
+                SC ->
+                    put(sc, SC),
+                    put(outh, #outh{}),
+                    deliver_400(CliSock, ReqEmptyAccept)
+            end,
+            {ok, Num+1};
         {error, {too_many_headers, ReqTooMany}} ->
             %% RFC 6585 status code 431
             ?Debug("Request headers too large~n", []),

--- a/www/multiple_accept_headers.yaws
+++ b/www/multiple_accept_headers.yaws
@@ -1,0 +1,11 @@
+<erl>
+%% @doc Extract the first mime-type from the Accept header list and respond
+%%      with it as Content-Type header.
+out(A) ->
+    AcceptHdr = yaws_api:headers_accept(yaws_api:arg_headers(A)),
+    [ContentType|_] = string:tokens(AcceptHdr, ","),
+
+    [{status, 200},
+     {header, {"Content-Type", ContentType}},
+     {header, {"X-Test-Request-Accept", AcceptHdr}}].
+</erl>


### PR DESCRIPTION
RFC 7230 HTTP/1.1 Message Syntax and Routing Section 3.2.2.  Field Order
states that a server MAY combine multiple header fields with the same
name into a comma-separated list [i.e. #(values)], withouth changing the
request semantics.

This change transforms multiple Accept headers in a request into such a
comma-separated list.