### PR TITLE
Remove version attribute from yaws_api:set_cookie/3

### DIFF
--- a/src/yaws_api.erl
+++ b/src/yaws_api.erl
@@ -729,7 +729,7 @@ set_cookie(Key, Value, Options)
         ({N,V}, {L1, L2}) -> {[cookie_option(N,V) | L1], L2};
         (N,     {L1, L2}) -> {L1, [cookie_option(N) | L2]}
     end, {[], []}, Options),
-    {header, {set_cookie, [Key, $=, Value, "; Version=1", NV | SV]}}.
+    {header, {set_cookie, [Key, $=, Value, NV | SV]}}.
 
 setcookie(Name, Value) ->
     {header, {set_cookie, f("~s=~s;", [Name, Value])}}.

--- a/testsuite/cookies_SUITE.erl
+++ b/testsuite/cookies_SUITE.erl
@@ -304,7 +304,7 @@ real_setcookies(_Config) ->
 
 set_cookie(_Config) ->
     ?assertEqual(
-        "a=bcd; Version=1; Comment=OK; Domain=g.com; Path=/; Max-Age=1; "
+        "a=bcd; Comment=OK; Domain=g.com; Path=/; Max-Age=1; "
         "Expires=Tue, 03 Jan 2012 10:00:05 GMT; HttpOnly; Secure",
         begin
             {header, {set_cookie, L}} = yaws_api:set_cookie("a", "bcd",
@@ -314,14 +314,14 @@ set_cookie(_Config) ->
             lists:flatten(L)
         end),
     ?assertEqual(
-        "a=bcd; Version=1; Path=/home",
+        "a=bcd; Path=/home",
         begin
             {header, {set_cookie, L}} =
                 yaws_api:set_cookie("a", "bcd", [{path, "/home"}]),
             lists:flatten(L)
         end),
     ?assertEqual(
-        "a=bcd; Version=1",
+        "a=bcd",
         begin
             {header, {set_cookie, L}} = yaws_api:set_cookie("a", "bcd", []),
             lists:flatten(L)


### PR DESCRIPTION
The `Version` cookie attribute no longer appears in RFC 6265.

Fixes #330.