### PR TITLE
Support for eccs SSL option (Elliptic Curve Cryptography).

### DIFF
--- a/doc/yaws.tex
+++ b/doc/yaws.tex
@@ -3419,6 +3419,18 @@ The following directives are allowed inside a server definition.
                  horrible sub-language of its own.  It is documented in the SSL
                  man page for "ciphers".
 
+               \item \verb+eccs = String+ --- This string specifies the
+                 supported Elliptic Curve Cryptography (ECC).
+                 It must be a subset of \textit{ssl:eccs()}.
+                 For PCI DSS compliance (which is the main reason why you
+                 would want to change this), set it on a single line to :
+\begin{verbatim}
+eccs = "[sect571r1, sect571k1, secp521r1, brainpoolP512r1, sect409k1,
+         sect409r1, brainpoolP384r1, secp384r1, sect283k1, sect283r1,
+         brainpoolP256r1, secp256k1, secp256r1, sect239k1, xsect233k1,
+         sect233r1, secp224k1, secp224r1]"
+\end{verbatim}
+
                \item \verb+secure_renegotiate = true | false+ --- Specifies whether
                  to reject renegotiation attempt that does not live up to RFC
                  5746. By default \verb+secure_renegotiate+ is set to false
@@ -3430,6 +3442,7 @@ The following directives are allowed inside a server definition.
                  disables the Erlang/OTP SSL application client
                  renegotiation option.  Defaults to true. See the
                  \verb+ssl+ manual page at
+                 
                  http://www.erlang.org/doc/man/ssl.html for more details.
 
                  \textbf{WARNING: This option was introduced in the SSL application

--- a/include/yaws.hrl
+++ b/include/yaws.hrl
@@ -134,7 +134,8 @@
                                    false -> undefined
                                end,
           protocol_version,
-          require_sni = false
+          require_sni = false,
+          eccs
          }).
 
 

--- a/src/yaws.erl
+++ b/src/yaws.erl
@@ -102,7 +102,8 @@
          ssl_client_renegotiation/1, ssl_client_renegotiation/2,
          ssl_protocol_version/1, ssl_protocol_version/2,
          ssl_honor_cipher_order/1, ssl_honor_cipher_order/2,
-         ssl_require_sni/1, ssl_require_sni/2]).
+         ssl_require_sni/1, ssl_require_sni/2,
+         ssl_eccs/1, ssl_eccs/2]).
 
 -export([new_deflate/0,
          deflate_min_compress_size/1, deflate_min_compress_size/2,
@@ -484,6 +485,7 @@ ssl_client_renegotiation(#ssl{client_renegotiation = X}) -> X.
 ssl_protocol_version    (#ssl{protocol_version     = X}) -> X.
 ssl_honor_cipher_order  (#ssl{honor_cipher_order   = X}) -> X.
 ssl_require_sni         (#ssl{require_sni          = X}) -> X.
+ssl_eccs                (#ssl{eccs                 = X}) -> X.
 
 ssl_keyfile             (S, File)    -> S#ssl{keyfile              = File}.
 ssl_certfile            (S, File)    -> S#ssl{certfile             = File}.
@@ -498,6 +500,7 @@ ssl_cachetimeout        (S, Timeout) -> S#ssl{cachetimeout         = Timeout}.
 ssl_secure_renegotiate  (S, Bool)    -> S#ssl{secure_renegotiate   = Bool}.
 ssl_protocol_version    (S, Vsns)    -> S#ssl{protocol_version     = Vsns}.
 ssl_require_sni         (S, Bool)    -> S#ssl{require_sni          = Bool}.
+ssl_eccs                (S, ECCS)    -> S#ssl{eccs                 = ECCS}.
 ssl_honor_cipher_order  (S, Bool) ->
     case yaws_dynopts:have_ssl_honor_cipher_order() of
         true  -> S#ssl{honor_cipher_order   = Bool};
@@ -544,7 +547,9 @@ setup_ssl(SL, DefaultSSL) ->
                  protocol_version     = lkup(protocol_version, SSLProps,
                                              undefined),
                  require_sni          = lkup(require_sni, SSLProps,
-                                             SSL#ssl.require_sni)}
+                                             SSL#ssl.require_sni),
+                 eccs                 = lkup(eccs, SSLProps, SSL#ssl.eccs)
+                }
     end.
 
 

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1004,6 +1004,11 @@ ssl_listen_opts(#sconf{ssl=SSL}) ->
             true ->
                  false
          end,
+         if SSL#ssl.eccs /= undefined ->
+                 {eccs, SSL#ssl.eccs};
+            true ->
+                 false
+         end,
          case yaws_dynopts:have_ssl_log_alert() of
              true  -> {log_alert, false};
              false -> false


### PR DESCRIPTION
Hi,

 We have customers with strong security policies. One of them is to be "PCI DSS compliant".

See "Strong Cryptography" in https://www.pcisecuritystandards.org/documents/PCI_DSS_Glossary_v3-2.pdf#page=21  where ECC with 224 bits and higher is recommended.,

Erlang SSL allows to pass an eccs option when dealing with sockets in order to specify the ECCs to be used.

This patch does the same thing as for the 'ciphers' SSL option, passing the options from yaws.conf to ssl:listen.

