### PR TITLE
Handle trailing white spaces in yaws_server:body_method/4

### DIFF
--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1734,7 +1734,7 @@ body_method(CliSock, IPPort, Req, Head) ->
               {_, undefined} ->
                   <<>>;
               {_, Len} ->
-                  Int_len = list_to_integer(string:strip(Len, right)),
+                  Int_len = strip_list_to_integer(Len),
                   if
                       Int_len < 0 ->
                           {error, content_length_overflow};

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1734,7 +1734,7 @@ body_method(CliSock, IPPort, Req, Head) ->
               {_, undefined} ->
                   <<>>;
               {_, Len} ->
-                  Int_len = list_to_integer(Len),
+                  Int_len = list_to_integer(string:strip(Len, right)),
                   if
                       Int_len < 0 ->
                           {error, content_length_overflow};


### PR DESCRIPTION
in accordance with the spec
https://tools.ietf.org/html/rfc7230#section-3.2:

    header-field = field-name ":" OWS field-value OWS

This fix is prompted by the following entry that shows up in
report.log from time to time:

=ERROR REPORT==== 3-Apr-2019::18:19:00.139688 ===
Yaws process died:
    {badarg,
        [{erlang,list_to_integer,["0 "],[]},
         {yaws_server,body_method,4,
             [{file, "/myapp/_build/default/lib/yaws/src/yaws_server.erl"},
              {line,1737}]},
         {yaws_server,aloop,4,
             [{file, "/myapp/_build/default/lib/yaws/src/yaws_server.erl"},
              {line,1261}]},
         {yaws_server,acceptor0,2,
             [{file, "/myapp/_build/default/lib/yaws/src/yaws_server.erl"},
              {line,1073}]},
         {proc_lib,init_p_do_apply,3,
             [{file,"proc_lib.erl"},{line,249}]}]}