### PR TITLE
Store the current appmod name in the #arg{} record

### DIFF
--- a/doc/yaws.tex
+++ b/doc/yaws.tex
@@ -605,12 +605,11 @@ request such as:
 
 \begin{verbatim}
 
-
 -record(arg, {
           clisock,        % the socket leading to the peer client
           client_ip_port, % {ClientIp, ClientPort} tuple
           headers,        % headers
-          req,            % request
+          req,            % request (possibly rewritten)
           orig_req,       % original request
           clidata,        % The client data (as a binary in POST requests)
           server_path,    % The normalized server path
@@ -633,9 +632,11 @@ request such as:
                           %  ie http://some.host/<prepath>/<script-point>/d/e
                           % where <script-point> is an appmod mount point,
                           % or .yaws,.php,.cgi,.fcgi etc script file.
-          pathinfo        % Set to '/d/e' when calling c.yaws for the request
+          pathinfo,       % Set to '/d/e' when calling c.yaws for the request
                           % http://some.host/a/b/c.yaws/d/e
                           %  equiv of cgi PATH_INFO
+          appmod_name     % name of the appmod handling a request,
+                          % or undefined if not applicable
          }).
 
 -record(http_request, {method,
@@ -1934,7 +1935,7 @@ detect a \verb+Content-Length+ header.
   \verb+out/1+. All bindings can then be used in the rest of
   \Yaws\ code (in HTML source and within \verb+erl+ tags).  In HTML
   source \verb+%%Key%%+ is expanded to \verb+Value+ and within
-  \verb+erl+ tags \\ \verb+yaws_api:binding(Key)+ (which calls
+  \verb+erl+ tags \verb+yaws_api:binding(Key)+ (which calls
   \verb+error+ if no such binding exists) or
   \verb+yaws_api:binding_find(Key)+ (which returns \verb+undefined+ if
   no such binding exists) can be used to extract \verb+Value+, and
@@ -3761,7 +3762,13 @@ protocol_version = tlsv1.2, tlsv1.1, tlsv1
                       keys and strings as header values
 
                     \item \verb+Arg+ --- an \verb+#arg{}+ record
-                      representing the request
+                      representing the request. In cases where an
+                      \verb+extramod+ module is called following the
+                      invocation of an appmod, the \verb+#arg{}+
+                      record field \verb+appmod_name+ indicates the
+                      name of the appmod that serviced the request,
+                      allowing the \verb+extramod+ to return extra
+                      HTTP headers appropriate for that appmod.
 
                     \item \verb+{StatusCode,Version}+ --- a tuple
                       where \verb+StatusCode+ is the numeric HTTP

--- a/include/yaws_api.hrl
+++ b/include/yaws_api.hrl
@@ -32,9 +32,11 @@
                           %  ie http://some.host/<prepath>/<script-point>/d/e
                           % where <script-point> is an appmod mount point,
                           % or .yaws,.php,.cgi,.fcgi etc script file.
-          pathinfo        % Set to '/d/e' when calling c.yaws for the request
+          pathinfo,       % Set to '/d/e' when calling c.yaws for the request
                           % http://some.host/a/b/c.yaws/d/e
                           %  equiv of cgi PATH_INFO
+          appmod_name     % name of the appmod handling a request,
+                          % or undefined if not applicable
          }).
 
 

--- a/man/yaws.conf.5
+++ b/man/yaws.conf.5
@@ -1539,7 +1539,11 @@ keys and strings as header values
 
 .TP
 \fBArg\Fr
-An \fI#arg{}\fR record representing the request
+An \fI#arg{}\fR record representing the request. In cases where an
+\fIextramod\fR module is called following the invocation of an appmod,
+the \fI#arg{}\fR record field \fIappmod_name\fR indicates the name of
+the appmod that serviced the request, allowing the \fIextramod\fR to
+return extra HTTP headers appropriate for that appmod.
 
 .TP
 \fB{StatusCode,Version}\fR

--- a/man/yaws_api.5
+++ b/man/yaws_api.5
@@ -46,7 +46,7 @@ We have the following relevant record definitions:
           clisock,        % the socket leading to the peer client
           client_ip_port, % {ClientIp, ClientPort} tuple
           headers,        % headers
-          req,            % request
+          req,            % request (possibly rewritten)
           orig_req,       % original request
           clidata,        % The client data (as a binary in POST requests)
           server_path,    % The normalized server path
@@ -69,9 +69,11 @@ We have the following relevant record definitions:
                           %  ie http://some.host/<prepath>/<script-point>/d/e
                           % where <script-point> is an appmod mount point,
                           % or .yaws,.php,.cgi,.fcgi etc script file.
-          pathinfo        % Set to '/d/e' when calling c.yaws for the request
+          pathinfo,       % Set to '/d/e' when calling c.yaws for the request
                           % http://some.host/a/b/c.yaws/d/e
                           %  equiv of cgi PATH_INFO
+          appmod_name     % name of the appmod handling a request,
+                          % or undefined if not applicable
          }).
 .fi
 \fR

--- a/src/yaws_server.erl
+++ b/src/yaws_server.erl
@@ -1949,7 +1949,8 @@ handle_request(CliSock, ARG, N) ->
                                           data = {yaws_revproxy, []}},
                             ARG1 = ARG#arg{server_path = DecPath,
                                            querydata   = QueryString,
-                                           state       = PP},
+                                           state       = PP,
+                                           appmod_name = yaws_revproxy},
                             handle_normal_request(CliSock, ARG1, UT,
                                                   SC#sconf.authdirs, N)
                     end
@@ -1976,7 +1977,7 @@ handle_normal_request(CliSock, ARG, UT, Authdirs, N) ->
             %% appmod_prepath with prepath.
             case UT#urltype.type of
                 appmod ->
-                    {_Mod, PathInfo} = UT#urltype.data,
+                    {Mod, PathInfo} = UT#urltype.data,
                     Appmoddata = case PathInfo of
                                      undefined ->
                                          undefined;
@@ -1987,7 +1988,8 @@ handle_normal_request(CliSock, ARG, UT, Authdirs, N) ->
                                                          PathInfo)
                                  end,
                     ARG2 = ARG1#arg{appmoddata     = Appmoddata,
-                                    appmod_prepath = UT#urltype.dir};
+                                    appmod_prepath = UT#urltype.dir,
+                                    appmod_name    = Mod};
                 _ ->
                     ARG2 = ARG1
             end,
@@ -1999,7 +2001,6 @@ handle_normal_request(CliSock, ARG, UT, Authdirs, N) ->
                            path = ARG1#arg.server_path},
             handle_ut(CliSock, ARG1, UT1, N)
     end.
-
 
 set_auth_user(ARG, User) ->
     H = ARG#arg.headers,

--- a/testsuite/main_SUITE_data/app_test.erl
+++ b/testsuite/main_SUITE_data/app_test.erl
@@ -1,10 +1,11 @@
 -module(app_test).
-
 -export([out/1]).
+
+-include("yaws_api.hrl").
 
 -define(APPMOD_HEADER, "Appmod-Called").
 
-out(_A) ->
+out(#arg{appmod_name=?MODULE}) ->
     %% add our special header to mark that we were here
     [{status, 200},
      {header, {?APPMOD_HEADER, "true"}}].

--- a/testsuite/main_SUITE_data/appmod1.erl
+++ b/testsuite/main_SUITE_data/appmod1.erl
@@ -1,7 +1,9 @@
 -module(appmod1).
 -export([out/1]).
 
-out(Arg) ->
+-include("yaws_api.hrl").
+
+out(#arg{appmod_name=?MODULE}=Arg) ->
     case yaws_api:arg_server_path(Arg) of
         "/chained" ->
             put(appmod_stack, "appmod1[/chained]"),

--- a/testsuite/main_SUITE_data/extra_resp_hdrs.erl
+++ b/testsuite/main_SUITE_data/extra_resp_hdrs.erl
@@ -1,13 +1,22 @@
 -module(extra_resp_hdrs).
 -export([extra_response_headers/3]).
 
+-include("yaws_api.hrl").
+
 %% This test adds extra headers to the response. The addition of
 %% Set-Cookie verifies that the response to the client contains
 %% multiple instances of the Set-Cookie header in the order specified
 %% here. The addition of X-Multi verifies that only on such header is
 %% in the client response, with a comma-separated value consisting of
 %% the two values here.
-extra_response_headers(OutHdrs, _Arg, _Status) ->
+%%
+%% The #arg{} record in the function head verifies that the
+%% appmod_name field is set to one used by the test client.
+extra_response_headers(OutHdrs, #arg{appmod_name=AppmodName}, _Status) ->
+    error_logger:format("AppModName is ~p~n", [AppmodName]),
+    true = AppmodName =:= appmod_strip_undefined_bindings orelse
+        AppmodName =:= status orelse
+        AppmodName =:= undefined,
     OutHdrs#{"X-ExtraMod" => atom_to_list(?MODULE),
              "Set-Cookie" => {multi, ["cookie1=ABCDEFG",
                                       "cookie2=1234567"]},


### PR DESCRIPTION
The reason for this is to make it possible for the
extra_response_header callback to know in which
appmod context it is executing and hence be able to
return the proper set of extra HTTP headers.