### PR TITLE
Fix #394 set content type charset when returning 404 page

### DIFF
--- a/src/yaws_outmod.erl
+++ b/src/yaws_outmod.erl
@@ -32,11 +32,21 @@ out404(Arg, GC, SC) ->
     Req = Arg#arg.orig_req,
     {abs_path, Path} = Req#http_request.path,
     B = not_found_body(Path, GC, SC),
+    ContentType = content_type("html", "text/html"),
     [{status, 404},
-     {header, {content_type, "text/html"}},
+     {header, {content_type, ContentType}},
      {header, {connection, "close"}},
      {html, B}].
 
+
+content_type(Ext, Default) ->
+    try
+        {regular, MimeType} = mime_types:t(Ext),
+        MimeType
+    catch
+        _:_ ->
+            Default
+    end.
 
 
 %% The default error 401 error delivery module


### PR DESCRIPTION
When returning the default '404 Not Found' page, the content
type was hardcoded to 'text/html', i.e with no charset information.

Now we make use of the 'mime_types' module to get the proper
content type (which takes into account what charset that has
been configured).